### PR TITLE
[qt5-feedback-haptics-droid-vibrator] Implement QFeedbackHapticsInterface. Contributes to JB#35546

### DIFF
--- a/droid-vibrator.json
+++ b/droid-vibrator.json
@@ -1,1 +1,1 @@
-{ "Interfaces": [ "QFeedbackThemeInterface" ] }
+{ "Interfaces": [ "QFeedbackHapticsInterface", "QFeedbackThemeInterface" ] }

--- a/droid-vibrator.pro
+++ b/droid-vibrator.pro
@@ -8,6 +8,7 @@ PLUGIN_TYPE = feedback
 
 HEADERS += qfeedback.h
 SOURCES += qfeedback.cpp
+OTHER_FILES += droid-vibrator.json
 
 CONFIG += link_pkgconfig
 PKGCONFIG += android-headers libhardware libvibrator

--- a/qfeedback.h
+++ b/qfeedback.h
@@ -44,10 +44,12 @@
 
 #include <QObject>
 #include <QTimerEvent>
+#include <QLoggingCategory>
 #include <qfeedbackplugininterfaces.h>
 
 #include <profile.h>
 
+Q_DECLARE_LOGGING_CATEGORY(qtFeedbackDroidVibrator)
 
 QT_BEGIN_HEADER
 


### PR DESCRIPTION
Previously, this plugin only implemented the QFeedbackThemeInterface.
This commit adds support for custom feedback effects (however only
supporting a single fixed intensity).

Contributes to JB#35546
