### PR TITLE
[qt5-feedback-haptics-droid-vibrator] Suppress category logs if not explicitly enabled. Fixes JB#38103

### DIFF
--- a/qfeedback.cpp
+++ b/qfeedback.cpp
@@ -51,7 +51,7 @@
 
 #include <hardware_legacy/vibrator.h>
 
-Q_LOGGING_CATEGORY(qtFeedbackDroidVibrator, "Qt.Feedback.DroidVibrator")
+Q_LOGGING_CATEGORY(qtFeedbackDroidVibrator, "qt.Feedback.DroidVibrator")
 
 QFeedbackDroidVibrator::QFeedbackDroidVibrator(QObject *parent)
     : QObject(parent)


### PR DESCRIPTION
By default logging categories starting with lower case qt are
disabled, others are enabled.

https://git.merproject.org/mer-core/qtbase/blob/mer-5.6/src/corelib/io/qloggingregistry.cpp#L416